### PR TITLE
📦 NEW: Add gtag for Google Analytics. Add multiple config files for d…

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 Generate icons here:
 
 [Real Favicon Generator](https://realfavicongenerator.net/favicon_result?file_id=p1dbp261ff1qqs1skeu581op41qc6#.XOoFXlNKh24)
+
+# Build tips
+
+[Use different configs](https://github.com/USFWS/southeast/blob/295e121da0887e2a5d1760c79f0a320688cfd15b/build/hugo.js)

--- a/buildspec.production.yml
+++ b/buildspec.production.yml
@@ -4,6 +4,7 @@ env:
   variables:
     s3_output: "www.ticnsp.org"
     hugo_version: "0.55.6"
+    hugo_config: "production.config.toml"
 
 phases:
   install:
@@ -17,7 +18,7 @@ phases:
   build:
     commands:
       - mkdir content # hugo needs this
-      - hugo
+      - hugo --config=${hugo_config}
       - cd public && aws s3 sync . s3://${s3_output} --delete --acl public-read
       - aws cloudfront create-invalidation --distribution-id E3QOGKHYJTGGFE --paths /
     finally:

--- a/buildspec.staging.yml
+++ b/buildspec.staging.yml
@@ -4,6 +4,7 @@ env:
   variables:
     s3_output: "staging.www.ticnsp.org"
     hugo_version: "0.55.6"
+    hugo_config: "staging.config.toml"
 
 phases:
   install:
@@ -17,7 +18,7 @@ phases:
   build:
     commands:
       - mkdir content # hugo needs this
-      - hugo
+      - hugo --config=${hugo_config}
       - cd public && aws s3 sync . s3://${s3_output} --delete --acl public-read
       - aws cloudfront create-invalidation --distribution-id E3PFRPSNHNYW3 --paths /
     finally:

--- a/layouts/partials/gtag.html
+++ b/layouts/partials/gtag.html
@@ -1,0 +1,9 @@
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-50407130-2"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag() { dataLayer.push(arguments); }
+        gtag('js', new Date());
+
+        gtag('config', 'UA-50407130-2');
+    </script>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,3 +1,7 @@
+	{{ if .Site.Params.gtag.enable }}
+  		{{ partial "gtag.html" .}}
+  	{{ end }}
+
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title> {{ .Title }}</title>

--- a/production.config.toml
+++ b/production.config.toml
@@ -1,6 +1,6 @@
 # Page settings
-baseurl = "http://localhost:1313/"
-BaseURL = "http://localhost:1313/"
+baseurl = "https://www.ticnsp.org/"
+BaseURL = "https://www.ticnsp.org/"
 title = "tic.nsp"
 languageCode = "en-us"
 theme = "hugo-elate-theme"
@@ -8,7 +8,7 @@ theme = "hugo-elate-theme"
 [params]
 
   [params.gtag]
-    enable = false
+    enable = true
   
   custom_css = ["css/override.css"]
 

--- a/staging.config.toml
+++ b/staging.config.toml
@@ -1,6 +1,6 @@
 # Page settings
-baseurl = "http://localhost:1313/"
-BaseURL = "http://localhost:1313/"
+baseurl = "https://staging.ticnsp.org/"
+BaseURL = "https://staging.ticnsp.org/"
 title = "tic.nsp"
 languageCode = "en-us"
 theme = "hugo-elate-theme"


### PR DESCRIPTION
# Description

This PR adds a new gtag.html partial for the header of the site to track it with Google Analytics.
Also, it adds new configuration files for the different environments so not all builds have google analytics tracking built in.