### PR TITLE
👌 IMPROVE: Add parameter store to hide distribution id

### DIFF
--- a/buildspec.production.yml
+++ b/buildspec.production.yml
@@ -5,6 +5,8 @@ env:
     s3_output: "www.ticnsp.org"
     hugo_version: "0.55.6"
     hugo_config: "production.config.toml"
+  parameter-store:
+    distribution_id: "www.ticnsp.org-distributionId"
 
 phases:
   install:
@@ -20,6 +22,6 @@ phases:
       - mkdir content # hugo needs this
       - hugo --config=${hugo_config}
       - cd public && aws s3 sync . s3://${s3_output} --delete --acl public-read
-      - aws cloudfront create-invalidation --distribution-id E3QOGKHYJTGGFE --paths /
+      - aws cloudfront create-invalidation --distribution-id ${distribution_id} --paths /
     finally:
       - echo "Script finished running"

--- a/buildspec.staging.yml
+++ b/buildspec.staging.yml
@@ -5,6 +5,8 @@ env:
     s3_output: "staging.www.ticnsp.org"
     hugo_version: "0.55.6"
     hugo_config: "staging.config.toml"
+  parameter-store:
+    distribution_id: "staging.www.ticnsp.org-distributionId"
 
 phases:
   install:
@@ -20,6 +22,6 @@ phases:
       - mkdir content # hugo needs this
       - hugo --config=${hugo_config}
       - cd public && aws s3 sync . s3://${s3_output} --delete --acl public-read
-      - aws cloudfront create-invalidation --distribution-id E3PFRPSNHNYW3 --paths /
+      - aws cloudfront create-invalidation --distribution-id ${distribution_id} --paths /
     finally:
       - echo "Script finished running"


### PR DESCRIPTION
This PR adds a parameter store configuration to the buildspec files to hide the distributionId